### PR TITLE
Add note about non-applicability to mDNS

### DIFF
--- a/draft-ietf-dnssd-multi-qtypes.md
+++ b/draft-ietf-dnssd-multi-qtypes.md
@@ -68,7 +68,9 @@ options verbatim.
 
 The specification described herein is applicable both for queries from a
 stub resolver to recursive servers, and from recursive resolvers to
-authoritative servers.
+authoritative servers. It does not apply to Multicast DNS queries
+{{?RFC6762}}, which are already designed to allow requesting multiple
+records in a single query.
 
 # Terminology used in this document
 


### PR DESCRIPTION
As this draft is being discussed in the dnssd group, one might think that it applies to mDNS queries commonly used for DNS service discovery as well, which is not actually the case. I think clarification would help; at least I was confused by that point and had to confirm by email.

Some notes about the context of this draft in the dnssd WG would help as well, maybe someone else can add a bit of context around that afterwards.