### PR TITLE
Unset rd and ra bits in example response from authoritative server

### DIFF
--- a/draft-ietf-dnssd-multi-qtypes.md
+++ b/draft-ietf-dnssd-multi-qtypes.md
@@ -353,7 +353,7 @@ is omitted from the MQTYPE-Response field.
 
 ~~~~~~~~~~~
 ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 33333
-;; flags: qr rd ra aa
+;; flags: qr aa
 ;; QUERY: 1, ANSWER: 5, AUTHORITY: 0, ADDITIONAL: 1
 
 ;; OPT PSEUDOSECTION:


### PR DESCRIPTION
It would be reasonable if the recursive resolver does not have the rd bit set and if the authoritative server does not have the ra bit set.